### PR TITLE
Potential fix for code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/contrib/spendfrom/spendfrom.py
+++ b/contrib/spendfrom/spendfrom.py
@@ -74,11 +74,11 @@ def connect_JSON(config):
         # ServiceProxy is lazy-connect, so send an RPC command mostly to catch connection errors,
         # but also make sure the bitcoind we're talking to is/isn't testnet:
         if result.getmininginfo()['testnet'] != testnet:
-            sys.stderr.write("RPC server at "+connect+" testnet setting mismatch\n")
+            sys.stderr.write("RPC server at 127.0.0.1:%s testnet setting mismatch\n" % str(config['rpcport']))
             sys.exit(1)
         return result
     except:
-        sys.stderr.write("Error connecting to RPC server at "+connect+"\n")
+        sys.stderr.write("Error connecting to RPC server at 127.0.0.1:%s\n" % str(config['rpcport']))
         sys.exit(1)
 
 def unlock_wallet(bitcoind):


### PR DESCRIPTION
Potential fix for [https://github.com/oldmagic/IRCoin/security/code-scanning/2](https://github.com/oldmagic/IRCoin/security/code-scanning/2)

The best way to fix this problem is to modify the error reporting on line 81 so that the password (and ideally the username) from the RPC connection string is not logged. We should avoid displaying values pulled from sensitive configuration such as `rpcuser` and `rpcpassword`. Instead, the error log should only state the RPC server address and port, omitting credentials. 

Specifically, line 81 (`sys.stderr.write("Error connecting to RPC server at "+connect+"\n")`) should be changed so that only the address/port are displayed:
- Change the construction of the error message to exclude the username and password.
- The host and port can be logged, but not the credentials.
- If desired, consider making the error more informative (e.g., "Error connecting to RPC server at 127.0.0.1:XXXX").

Only lines relevant to the vulnerable output and directly-contributing variables will be changed, with context preserved.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
