### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/contrib/spendfrom/spendfrom.py
+++ b/contrib/spendfrom/spendfrom.py
@@ -74,11 +74,13 @@ def connect_JSON(config):
         # ServiceProxy is lazy-connect, so send an RPC command mostly to catch connection errors,
         # but also make sure the bitcoind we're talking to is/isn't testnet:
         if result.getmininginfo()['testnet'] != testnet:
-            sys.stderr.write("RPC server at "+connect+" testnet setting mismatch\n")
+            redacted_connect = "http://%s:***@127.0.0.1:%s" % (config['rpcuser'], config['rpcport'])
+            sys.stderr.write("RPC server at "+redacted_connect+" testnet setting mismatch\n")
             sys.exit(1)
         return result
     except:
-        sys.stderr.write("Error connecting to RPC server at "+connect+"\n")
+        redacted_connect = "http://%s:***@127.0.0.1:%s" % (config['rpcuser'], config['rpcport'])
+        sys.stderr.write("Error connecting to RPC server at "+redacted_connect+"\n")
         sys.exit(1)
 
 def unlock_wallet(bitcoind):


### PR DESCRIPTION
Potential fix for [https://github.com/oldmagic/IRCoin/security/code-scanning/1](https://github.com/oldmagic/IRCoin/security/code-scanning/1)

To fix the problem, we should prevent the RPC password from ever being logged. Instead of including the full `connect` URI (which contains both username and password) in log messages, we can log only non-sensitive information, such as the RPC username and port. We can, for instance, replace occurrences of `connect` in error messages with a sanitized string that lists only the username and port, or redact the password entirely.

The required changes are:
1. In the error message on line 77, avoid logging the full `connect` string. Log only non-sensitive information. 
2. This may involve constructing a new string (with just the username and port, or with the password replaced by a fixed string such as `***`).
3. No new external libraries are needed.
4. The exact lines to change are in the `connect_JSON(config)` function, line 77.
5. We need a way to construct a redacted URI or summary for logging.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
